### PR TITLE
Adding multi devices with home assistant

### DIFF
--- a/src/home_assistant.ts
+++ b/src/home_assistant.ts
@@ -1,6 +1,6 @@
 import { Client } from "./mqtt";
 import { TargetConfig } from "./types";
-import { md5, slugify } from "./util";
+import { md5, slugify, ConvertIPToHexIP } from "./util";
 
 export const createHomeAssistantTopics = async (
     mqtt: Client,
@@ -31,7 +31,8 @@ export const createHomeAssistantTopics = async (
                 ? "binary_sensor"
                 : "sensor";
             const sensorName = slugify(sensor.name);
-            const topic = `${prefix}/${sensorType}/snmp2mqtt/${sensorName}/config`;
+            const deviceId = ConvertIPToHexIP(target.host);
+            const topic = `${prefix}/${sensorType}/${deviceId}/${sensorName}/config`;
 
             const discovery: any = {
                 availability: [

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,4 +11,13 @@ export function slugify(str: string) {
     ).replace(/^_+|_+$/g, "");
 }
 
+export function ConvertIPToHexIP(ip) {
+    var vals = ip.split(".");
+    var op = ['0x'];
+    for (var i = 0; i < vals.length; i++) {
+        op.push(Number(vals[i]).toString(16));
+    }
+    return op.join("");
+}
+
 export const md5 = (str: string) => createHash("md5").update(str).digest("hex");

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,7 @@ export function slugify(str: string) {
     ).replace(/^_+|_+$/g, "");
 }
 
-export function ConvertIPToHexIP(ip) {
+export function ConvertIPToHexIP(ip: string) {
     var vals = ip.split(".");
     var op = ['0x'];
     for (var i = 0; i < vals.length; i++) {


### PR DESCRIPTION
This solves an issue when using Home Assistant as a target. Prior this patch, it was not possible to have same sensor names for different devices. With this patch, the device name in the discovery topic is no more static "snmp2mqtt".