### PR TITLE
Bump luxon and @types/luxon

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
         "better-ajv-errors": "^1.1.2",
         "bigint-buffer": "^1.1.5",
         "js-yaml": "^4.1.0",
-        "luxon": "^2.3.0",
+        "luxon": "^3.0.1",
         "net-snmp": "^3.5.8",
         "slugify": "^1.6.5"
     },
     "devDependencies": {
         "@tsconfig/node16": "^1.0.2",
         "@types/js-yaml": "^4.0.5",
-        "@types/luxon": "^2.0.8",
+        "@types/luxon": "^3.0.0",
         "@types/node": "^14.14.27",
         "prettier": "^2.5.1",
         "ts-node": "^10.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
-"@types/luxon@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.0.8.tgz#a0fdd7ab0b67e08bf1d301232a7fef79b74ded69"
-  integrity sha512-lGmxL6hMEVqXr8w9bL52RUWXVu90o7vH8WQSutQssr2e+w0TNttXx2Zfw2V2lHHHWfW6OGqB8bXDvtKocv19qQ==
+"@types/luxon@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.0.0.tgz#47fb7891e41875fce7018a8bd3d09b204c5621f5"
+  integrity sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw==
 
 "@types/node@^14.14.27":
   version "14.14.27"
@@ -492,10 +492,10 @@ leven@^2.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-luxon@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.3.0.tgz#bf16a7e642513c2a20a6230a6a41b0ab446d0045"
-  integrity sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg==
+luxon@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.0.1.tgz#6901111d10ad06fd267ad4e4128a84bef8a77299"
+  integrity sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw==
 
 make-error@^1.1.1:
   version "1.3.6"


### PR DESCRIPTION
Bumps [luxon](https://github.com/moment/luxon) and [@types/luxon](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/luxon). These dependencies needed to be updated together.

Updates `luxon` from 2.3.0 to 3.0.1
- [Release notes](https://github.com/moment/luxon/releases)
- [Changelog](https://github.com/moment/luxon/blob/master/CHANGELOG.md)
- [Commits](https://github.com/moment/luxon/compare/2.3.0...3.0.1)

Updates `@types/luxon` from 2.0.8 to 3.0.0
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/luxon)

---
updated-dependencies:
- dependency-name: luxon dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: "@types/luxon" dependency-type: direct:development update-type: version-update:semver-major ...